### PR TITLE
exposing javascript errors to the regular vs code output

### DIFF
--- a/assets/communication.js
+++ b/assets/communication.js
@@ -15,6 +15,15 @@ function setupCommunication() {
       });
     }
   });
+
+  window.addEventListener("error", (error) => {
+    vscode.postMessage({
+      type: "jsError",
+      containedMessage: error.message,
+      containedRawLine: error.lineno,
+      containedRawColumn: error.colno
+    });
+  });
 }
 
 window.addEventListener("load", setupCommunication);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,12 @@ import * as fs from "fs";
 import * as crypto from "crypto";
 import {resolveImports} from "./ImportSolver";
 
+/**
+ * This is used to correct the linu numbers we output on errors.
+ * This must be kept in sync with the script tag in `getWebviewContent()`
+ */
+const PRECEDING_LINES_IN_SCRIPT_TAG = 6;
+
 let outputChannel: vscode.OutputChannel;
 let currentPanel: vscode.WebviewPanel | undefined = undefined;
 let lastCodeHash: String = undefined;
@@ -172,6 +178,10 @@ function handleMessage(message: any) {
         }
       });
     }
+  } else if (message.type == "jsError") {
+    outputChannel.appendLine(`🦷: ${message.containedMessage} in Line ${message.containedRawLine - PRECEDING_LINES_IN_SCRIPT_TAG} / Column ${message.containedRawColumn}`);
+  } else {
+    outputChannel.appendLine(`unknown message of type "${message.type}" received`);
   }
 }
 


### PR DESCRIPTION
As reported in #40, currently JS errors will not be displayed anywhere.

First attempts at exposing a JavaScript error in the output-pane. It's not perfect, but it shows that it can be done. Hence the "WIP".

![error output in output](https://user-images.githubusercontent.com/124909/99245700-51a9e100-2804-11eb-926c-26e9217ed0f6.png)
